### PR TITLE
Schema edits

### DIFF
--- a/src/main/java/com/mofumo/api/entities/Booking.java
+++ b/src/main/java/com/mofumo/api/entities/Booking.java
@@ -58,11 +58,11 @@ public class Booking {
   @Column(name = "status")
   private String status;
 
-  @Column(name = "updated_at")
-  private Instant updatedAt;
-
   @Column(name = "created_at")
   private Instant createdAt;
+
+  @Column(name = "updated_at")
+  private Instant updatedAt;
 
   @OneToOne(mappedBy = "booking")
   private Payment payment;

--- a/src/main/java/com/mofumo/api/entities/Booking.java
+++ b/src/main/java/com/mofumo/api/entities/Booking.java
@@ -58,10 +58,10 @@ public class Booking {
   @Column(name = "status")
   private String status;
 
-  @Column(name = "updatedAt")
+  @Column(name = "updated_at")
   private Instant updatedAt;
 
-  @Column(name = "createdAt")
+  @Column(name = "created_at")
   private Instant createdAt;
 
   @OneToOne(mappedBy = "booking")

--- a/src/main/java/com/mofumo/api/entities/Payment.java
+++ b/src/main/java/com/mofumo/api/entities/Payment.java
@@ -40,7 +40,7 @@ public class Payment {
   @Column(name = "payment_date")
   private LocalDate paymentDate;
 
-  @Column(name = "createdAt")
+  @Column(name = "created_at")
   private Instant createdAt;
 
 }

--- a/src/main/java/com/mofumo/api/entities/Pet.java
+++ b/src/main/java/com/mofumo/api/entities/Pet.java
@@ -59,7 +59,7 @@ public class Pet {
   @Column(name = "active")
   private Boolean active = false;
 
-  @Column(name = "createdAt")
+  @Column(name = "created_at")
   private Instant createdAt;
 
   @OneToMany(mappedBy = "pet")

--- a/src/main/java/com/mofumo/api/entities/Provider.java
+++ b/src/main/java/com/mofumo/api/entities/Provider.java
@@ -31,6 +31,9 @@ public class Provider {
   @Column(name = "business_name")
   private String businessName;
 
+  @Column(name = "address")
+  private String address;
+
   @Column(name = "description")
   private String description;
 

--- a/src/main/java/com/mofumo/api/entities/Review.java
+++ b/src/main/java/com/mofumo/api/entities/Review.java
@@ -33,7 +33,7 @@ public class Review {
   private String comment;
 
   @ColumnDefault("CURRENT_TIMESTAMP")
-  @Column(name = "createdAt")
+  @Column(name = "created_at")
   private Instant createdAt;
 
 }

--- a/src/main/java/com/mofumo/api/entities/Service.java
+++ b/src/main/java/com/mofumo/api/entities/Service.java
@@ -43,7 +43,7 @@ public class Service {
   @Column(name = "active")
   private Boolean active = false;
 
-  @Column(name = "createdAt")
+  @Column(name = "created_at")
   private Instant createdAt;
 
   @OneToMany(mappedBy = "service")

--- a/src/main/java/com/mofumo/api/entities/User.java
+++ b/src/main/java/com/mofumo/api/entities/User.java
@@ -32,6 +32,9 @@ public class User {
   @Column(name = "phone")
   private String phone;
 
+  @Column(name = "address")
+  private String address;
+
   @Column(name = "line_id")
   private String lineId;
 
@@ -50,10 +53,10 @@ public class User {
   @Column(name = "active")
   private Boolean active;
 
-  @Column(name = "createdAt")
+  @Column(name = "created_at")
   private Timestamp createdAt;
 
-  @Column(name = "updatedAt")
+  @Column(name = "updated_at")
   private Timestamp updatedAt;
 
   // Pets, Reviews, Providers, Bookings

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -76,7 +76,7 @@ create table services
     duration_minutes int                                                                                        not null,
     price            int                                                                                        not null,
     active           boolean    default TRUE                                                                    not null,
-    createdAt        timestamp  default current_timestamp                                                       not null,
+    created_at       timestamp  default current_timestamp                                                       not null,
     constraint services_providers_id_fk
         foreign key (provider_id) references providers (id)
             on update cascade on delete cascade
@@ -133,8 +133,8 @@ create table bookings
     special_requests text                                                                                    null,
     total_price      int                                                                                     not null,
     status           enum ('pending', 'confirmed', 'completed', 'cancelled')   default 'pending'             not null,
-    updatedAt        timestamp default current_timestamp on update current_timestamp not null,
-    createdAt        timestamp                                                 default current_timestamp     not null,
+    updated_at       timestamp default current_timestamp on update current_timestamp not null,
+    created_at       timestamp                                                 default current_timestamp     not null,
 
     constraint bookings_pets_id_fk
         foreign key (pet_id) references pets (id)
@@ -158,7 +158,7 @@ create table reviews
     user_id    bigint                              not null,
     rating     int                                 not null,
     comment    text                                null,
-    createdAt  timestamp default current_timestamp not null,
+    created_at timestamp default current_timestamp not null,
     constraint reviews_bookings_id_fk
         foreign key (booking_id) references bookings (id),
     constraint reviews_users_id_fk
@@ -175,7 +175,7 @@ create table payments
     external_payment_id varchar(255)                                                                         not null,
     status              enum ('pending', 'confirmed', 'cancelled', 'declined') default 'pending'             not null,
     payment_date        date                                                   default (current_date())      not null,
-    createdAt           timestamp                                              default current_timestamp     not null,
+    created_at          timestamp                                              default current_timestamp     not null,
     constraint payments_bookings_id_fk
     foreign key (booking_id) references bookings (id)
 );

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -126,15 +126,15 @@ create table bookings
     pet_id           bigint                                                                                  not null,
     provider_id      bigint                                                                                  not null,
     service_id       binary(16)                                                                              not null,
-    booking_date     date                                                      default (current_date())        not null,
+    booking_date     date                                                      default (current_date())      not null,
     start_time       time                                                                                    not null,
     end_time         time                                                                                    not null,
     location_type    enum ('provider_location', 'customer_location', 'mobile') default 'provider_location'   not null,
     special_requests text                                                                                    null,
     total_price      int                                                                                     not null,
     status           enum ('pending', 'confirmed', 'completed', 'cancelled')   default 'pending'             not null,
-    updated_at       timestamp default current_timestamp on update current_timestamp not null,
     created_at       timestamp                                                 default current_timestamp     not null,
+    updated_at       timestamp default current_timestamp on update current_timestamp not null,
 
     constraint bookings_pets_id_fk
         foreign key (pet_id) references pets (id)

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -4,25 +4,31 @@ create table users
         primary key,
     email             varchar(255)                                         not null,
     password          varchar(255)                                         not null,
-    first_name         varchar(50)                                          not null,
+    first_name        varchar(50)                                          not null,
     last_name         varchar(50)                                          not null,
     phone             varchar(20)                                          not null,
+    address           varchar(255)                                         not null,
+    ward              enum('adachi', 'arakawa', 'bunkyo', 'chiyoda', 'chuo', 'edogawa',
+                           'itabashi', 'katsushika', 'kita', 'koto', 'meguro', 'minato',
+                           'nakano', 'nerima', 'ota', 'setagaya', 'shibuya', 'shinagawa',
+                           'shinjuku', 'suginami', 'sumida', 'taito', 'toshima'
+                      )                                                    null,
     line_id           varchar(255)                                         null,
-    ward              varchar(20)                                          null,
-    user_type         enum ('CUSTOMER', 'PROVIDER') default 'CUSTOMER'     not null,
+    user_type         enum ('customer', 'provider') default 'customer'     not null,
     preferred_lang    varchar(3)                    default 'en'           null,
     email_verified    boolean                       default FALSE          not null,
     active            boolean                                              not null,
-    createdAt         timestamp                     default CURRENT_TIMESTAMP not null,
-    updatedAt         timestamp                                            not null
+    created_at        timestamp                     default CURRENT_TIMESTAMP not null,
+    updated_at        timestamp                                            not null
 );
 
 create table providers
 (
     id                  bigint auto_increment
         primary key,
-    user_id              bigint                              not null,
+    user_id             bigint                              not null,
     business_name       varchar(100)                        not null,
+    address             varchar(255)                        not null,
     description         text                                not null,
     service_types       json                                not null,
     languages_spoken    json                                not null,
@@ -44,7 +50,7 @@ create table pets
         primary key,
     owner_id                bigint                                                                                      not null,
     name                    varchar(25)                                                                                 not null,
-    species                 enum ('DOG', 'CAT', 'FISH', 'BIRD', 'HAMSTER', 'RABBIT', 'OTHER') default 'OTHER'           not null,
+    species                 enum ('dog', 'cat', 'fish', 'bird', 'hamster', 'rabbit', 'other')                           not null,
     breed                   varchar(100)                                                                                null,
     age_yr                  int                                                                                         null,
     weight_kg               decimal(5, 2)                                                                               null,
@@ -53,7 +59,8 @@ create table pets
     emergency_contact_name  varchar(100)                                                                                not null,
     emergency_contact_phone varchar(20)                                                                                 not null,
     active                  boolean                                                           default TRUE              not null,
-    createdAt               timestamp                                                         default current_timestamp not null,
+    created_at              timestamp                                                         default current_timestamp not null,
+    updated_at              timestamp                                                         default current_timestamp not null,
     constraint pets_9_users_id_fk
         foreign key (owner_id) references users (id)
             on update cascade on delete cascade
@@ -65,7 +72,7 @@ create table services
         primary key,
     provider_id      bigint                                                                                     not null,
     service_name     varchar(50)                                                                                not null,
-    service_category enum ('GROOMING', 'VETERINARY', 'BOARDING', 'WALKING', 'TRAINING', 'DAYCARE', 'TRANSPORT') null,
+    service_category enum ('grooming', 'veterinary', 'boarding', 'walking', 'training', 'daycare', 'transport ') null,
     duration_minutes int                                                                                        not null,
     price            int                                                                                        not null,
     active           boolean    default TRUE                                                                    not null,
@@ -79,12 +86,12 @@ create table provider_availability
 (
     id              bigint auto_increment primary key,
     provider_id     bigint                                                           not null,
-    day_of_week     enum ('MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY') null,
+    day_of_week     enum ('monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday') null,
     available_date  date                                                             null,
     start_time      time                                                             not null,
     end_time        time                                                             not null,
     spans_midnight  boolean                                            default false not null,
-    recurrence_type enum ('one_time', 'weekly', 'monthly')                          not null,
+    recurrence_type enum ('one_time', 'weekly', 'monthly')                           not null,
     valid_from      date                                                             not null,
     valid_until     date                                                             null,
     is_blocked      boolean                                            default false not null,


### PR DESCRIPTION
This PR introduces updates to the initial database schema and related entity classes to ensure consistency between the schema and ORM mappings, and adds new support for user location via ward.

### Changes Made

V1__init_schema.sql:

- Added address field to users table as NOT NULL.
- Added ward field to users table using an ENUM:

enum('adachi', 'arakawa', 'bunkyo', 'chiyoda', 'chuo', 'edogawa',
     'itabashi', 'katsushika', 'kita', 'koto', 'meguro', 'minato',
     'nakano', 'nerima', 'ota', 'setagaya', 'shibuya', 'shinagawa',
     'shinjuku', 'suginami', 'sumida', 'taito', 'toshima')
     
All ENUM values changed to lowercase to align with best practices and simplify parsing in application code.

Renamed createdAt & updatedAt → created_at & updated_at in all relevant tables for better mapping with JPA/Hibernate.

Affected entities:

- Booking.java
- Service.java
- Review.java
- ProviderAvailability.java
- Provider.java
- Pet.java
- Payment.java

### Entity Changes
@Column(name = "created_at")
private Instant createdAt;

@Column(name = "updated_at")
private Instant updatedAt;