### PR TITLE
Prevent duplicate users

### DIFF
--- a/src/main/java/com/mofumo/api/controllers/GlobalExceptionHandler.java
+++ b/src/main/java/com/mofumo/api/controllers/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.mofumo.api.controllers;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -33,4 +34,22 @@ public class GlobalExceptionHandler {
     errors.put("Error", exception.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
   }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ResponseEntity<Map<String, String>> handleDataIntegrityViolation(
+          DataIntegrityViolationException exception
+  ){
+    // Check if the exception contains users_email_unique
+    if(exception.getMostSpecificCause().getMessage().contains("users_email_unique")) {
+      // Should return a status of 409 conflict
+      return ResponseEntity.status(HttpStatus.CONFLICT).body(
+              Map.of("Error", "Email address already in use.")
+      );
+    }
+    // Else, it means some other field has invalid data
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(
+            Map.of("Error", "Data Integrity Violation " + exception.getMessage())
+    );
+  }
+
 }

--- a/src/main/java/com/mofumo/api/dtos/RegisterUserRequest.java
+++ b/src/main/java/com/mofumo/api/dtos/RegisterUserRequest.java
@@ -1,6 +1,7 @@
 package com.mofumo.api.dtos;
 
 import com.mofumo.api.enums.UserType;
+import com.mofumo.api.enums.Ward;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -51,6 +52,8 @@ public class RegisterUserRequest {
           message = "Address contains invalid characters."
   )
   private String address;
+
+  private Ward ward;
 
   @Size(max = 2, message = "Preferred language can only have a maximum of 2 characters. (e.g. jp,en)")
   private String preferredLang;

--- a/src/main/java/com/mofumo/api/entities/User.java
+++ b/src/main/java/com/mofumo/api/entities/User.java
@@ -19,7 +19,7 @@ public class User {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(name = "email")
+  @Column(name = "email", unique = true)
   private String email;
 
   @Column(name = "password")

--- a/src/main/java/com/mofumo/api/repositories/UserRepository.java
+++ b/src/main/java/com/mofumo/api/repositories/UserRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
   User findByEmail(String email);
+  Boolean existsByEmail(String email);
 }

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -19,7 +19,9 @@ create table users
     email_verified    boolean                       default FALSE          not null,
     active            boolean                                              not null,
     created_at        timestamp                     default CURRENT_TIMESTAMP not null,
-    updated_at        timestamp                                            not null
+    updated_at        timestamp                                            not null,
+
+    constraint users_email_unique unique (email)
 );
 
 create table providers


### PR DESCRIPTION
This PR introduces a unique email constraint to the users table and adds proper exception handling for duplicate email registrations.

### Changes Made

1. Database Schema
- Added users_email_unique constraint to the users table for enforcing unique emails.

2. Repository Updates
- Added findByEmail and existsByEmail methods in UserRepository to support email lookups and pre-checks.

3. Global Exception Handling
- Added @ExceptionHandler(DataIntegrityViolationException.class) to catch database-level integrity errors.
- Returns 409 Conflict if the violation is caused by users_email_unique.
- Returns a generic conflict for other data integrity violations.

4. Behavior After Merge
- Attempting to register a user with a duplicate email will return a 409 conflict:
     {
       "Error": "Email address already in use."
     }

