### PR TITLE
Added endpoint (auth/me) to get authenticated user

### DIFF
--- a/src/main/java/com/mofumo/api/controllers/AuthController.java
+++ b/src/main/java/com/mofumo/api/controllers/AuthController.java
@@ -2,6 +2,7 @@ package com.mofumo.api.controllers;
 
 import com.mofumo.api.dtos.JwtResponse;
 import com.mofumo.api.dtos.LoginRequest;
+import com.mofumo.api.dtos.UserDto;
 import com.mofumo.api.mappers.UserMapper;
 import com.mofumo.api.repositories.UserRepository;
 import com.mofumo.api.services.JwtService;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
@@ -38,8 +40,10 @@ public class AuthController {
                   request.getPassword()
           )
     );
+
+    var user = userRepository.findByEmail(request.getEmail()).orElseThrow();
      // After authenticating the user generate a new token
-    var token = jwtService.generateToken(request.getEmail());
+    var token = jwtService.generateToken(user);
     return ResponseEntity.ok(new JwtResponse(token));
   }
 
@@ -48,6 +52,18 @@ public class AuthController {
   public Boolean validate(@RequestHeader("Authorization") String authHeader){
     var token = authHeader.replace("Bearer ", "");
     return jwtService.validateToken(token);
+  }
+
+  @GetMapping("/me")
+  public ResponseEntity<UserDto> me(){
+    var authentication = SecurityContextHolder.getContext().getAuthentication();
+    var userId = (Long) authentication.getPrincipal();
+    var user = userRepository.findById(userId).orElse(null);
+    if (user == null) {
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+    var userDto = userMapper.toDto(user);
+    return ResponseEntity.ok(userDto);
   }
 
   @ExceptionHandler(BadCredentialsException.class)

--- a/src/main/java/com/mofumo/api/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mofumo/api/filters/JwtAuthenticationFilter.java
@@ -45,7 +45,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // We need to create an authentication object
     var authentication = new UsernamePasswordAuthenticationToken(
             // First we need to get the subject
-            jwtService.getEmailFromToken(token),
+            jwtService.getUserIdFromToken(token),
             // Now we need credentials (null for now)\
             null,
             null

--- a/src/main/java/com/mofumo/api/services/JwtService.java
+++ b/src/main/java/com/mofumo/api/services/JwtService.java
@@ -1,5 +1,7 @@
 package com.mofumo.api.services;
 
+import com.mofumo.api.entities.User;
+import com.mofumo.api.repositories.UserRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -11,12 +13,21 @@ import java.util.Date;
 
 @Service
 public class JwtService {
+  private final UserRepository userRepository;
   @Value("${spring.jwt.secret}")
   private String secret;
-  public String generateToken(String email) {
+
+  public JwtService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  public String generateToken(User user) {
     final long tokenExpiration = 86400; // number of seconds in 1 day
     return Jwts.builder()
-            .subject(email)
+            .subject(user.getId().toString())
+            .claim("Email: ", user.getEmail())
+            .claim("Last Name: ", user.getLastName())
+            .claim("First Name: ", user.getFirstName())
             .issuedAt(new Date())
             // Set the expiration limit of the token
             .expiration(new Date(System.currentTimeMillis() + 1000 * tokenExpiration))
@@ -46,7 +57,7 @@ public class JwtService {
             .getPayload();
   }
 
-  public String getEmailFromToken(String token) {
-    return getClaims(token).getSubject();
+  public Long getUserIdFromToken(String token) {
+    return Long.valueOf(getClaims(token).getSubject());
   }
 }


### PR DESCRIPTION
This pull request introduces a new API endpoint at /auth/me that allows a client to retrieve the details of the currently authenticated user.

### Changes Include:

- A new GET endpoint at /auth/me in the AuthController.
- Fetching the authenticated user's ID from the SecurityContextHolder.
- Retrieving the user details from the database and mapping them to a UserDto.
- A crucial update to the JWT token generation to set the user's ID as the subject of the token, ensuring it is available in the security context.

### How to Test

1. Authenticate to receive a JWT token;  POST (/auth/login).
2. Use the token to make a GET request to /auth/me.
3. Confirm that the response is 200 OK and contains the correct UserDto for the user.