### PR TITLE
Implement Refresh Token

### DIFF
--- a/src/main/java/com/mofumo/api/controllers/AuthController.java
+++ b/src/main/java/com/mofumo/api/controllers/AuthController.java
@@ -52,7 +52,7 @@ public class AuthController {
     cookie.setHttpOnly(true);
     cookie.setSecure(true);
     cookie.setPath("/auth/refresh");
-    cookie.setMaxAge(300);
+    cookie.setMaxAge(604800);
     response.addCookie(cookie);
 
     return ResponseEntity.ok().body(new JwtResponse(accessToken));

--- a/src/main/java/com/mofumo/api/controllers/AuthController.java
+++ b/src/main/java/com/mofumo/api/controllers/AuthController.java
@@ -6,6 +6,8 @@ import com.mofumo.api.dtos.UserDto;
 import com.mofumo.api.mappers.UserMapper;
 import com.mofumo.api.repositories.UserRepository;
 import com.mofumo.api.services.JwtService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -31,7 +33,8 @@ public class AuthController {
 
   @PostMapping("/login")
   public ResponseEntity<JwtResponse> login(
-        @Valid @RequestBody LoginRequest request
+        @Valid @RequestBody LoginRequest request,
+        HttpServletResponse response
   ){
     // Authenticate the user email and password
     authenticationManager.authenticate(
@@ -43,8 +46,16 @@ public class AuthController {
 
     var user = userRepository.findByEmail(request.getEmail()).orElseThrow();
      // After authenticating the user generate a new token
-    var token = jwtService.generateToken(user);
-    return ResponseEntity.ok(new JwtResponse(token));
+    var accessToken = jwtService.generateAccessToken(user);
+    var refreshToken = jwtService.generateRefreshToken(user);
+    var cookie = new Cookie("refreshToken", refreshToken);
+    cookie.setHttpOnly(true);
+    cookie.setSecure(true);
+    cookie.setPath("/auth/refresh");
+    cookie.setMaxAge(300);
+    response.addCookie(cookie);
+
+    return ResponseEntity.ok().body(new JwtResponse(accessToken));
   }
 
   @PostMapping("/validate")

--- a/src/main/java/com/mofumo/api/services/JwtService.java
+++ b/src/main/java/com/mofumo/api/services/JwtService.java
@@ -6,31 +6,38 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Date;
 
+@RequiredArgsConstructor
 @Service
 public class JwtService {
   private final UserRepository userRepository;
   @Value("${spring.jwt.secret}")
   private String secret;
 
-  public JwtService(UserRepository userRepository) {
-    this.userRepository = userRepository;
+  public String generateAccessToken(User user) {
+    final long tokenExpiration = 300; // 5 minutes
+    return generateToken(user, tokenExpiration);
   }
 
-  public String generateToken(User user) {
-    final long tokenExpiration = 86400; // number of seconds in 1 day
+  public String generateRefreshToken(User user) {
+    final long tokenExpiration = 604800; // 7 days
+    return generateToken(user, tokenExpiration);
+  }
+
+  private String generateToken(User user, long tokenExpiration){
     return Jwts.builder()
             .subject(user.getId().toString())
             .claim("Email: ", user.getEmail())
             .claim("Last Name: ", user.getLastName())
             .claim("First Name: ", user.getFirstName())
             .issuedAt(new Date())
-            // Set the expiration limit of the token
-            .expiration(new Date(System.currentTimeMillis() + 1000 * tokenExpiration))
+            .expiration(new Date(System.currentTimeMillis() + tokenExpiration))
             .signWith(Keys.hmacShaKeyFor(secret.getBytes()))
             .compact();
   }


### PR DESCRIPTION
This pull request introduces a dedicated refresh token. It separates the short term access token used for API calls, from the longer term refresh token, used to obtain new access tokens without requiring the user to re-authenticate.

### Changes Made:

Token Separation: 
The Login endpoint now generates an access token (5 min) and a refresh token (7 days).

HTTP-Only Refresh Token Cookie: 
The refresh token is securely stored in an HttpOnly cookie. This prevents client side JavaScript from accessing the token.